### PR TITLE
close statements when closing conn.

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendConnection.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendConnection.java
@@ -197,7 +197,9 @@ public class DatabendConnection implements Connection, FileTransferAPI {
     @Override
     public void close()
             throws SQLException {
-
+        for (Statement stmt : statements) {
+            stmt.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
to avoid server side from waiting for timeout.

https://stackoverflow.com/questions/4507440/must-jdbc-resultsets-and-statements-be-closed-separately-although-the-connection