### PR TITLE
Fix jackson package conflict problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,10 @@
                                     <pattern>com.acme.coyote</pattern>
                                     <shadedPattern>hidden.coyote</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>com.databend.jdbc.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>
@@ -205,7 +209,7 @@
                     </execution>
                 </executions>
             </plugin>
-	    	<plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Linked issue https://github.com/databendcloud/databend-jdbc/issues/87

Rename jackson package to `com.databend.jdbc.com.fasterxml.jackson.*`

![image](https://github.com/databendcloud/databend-jdbc/assets/12069428/075b7530-a630-45ff-bc4f-02250515dc89)

