### PR TITLE
Fix conversion error when boolean type is returned as string

### DIFF
--- a/databend-client/src/main/java/com/databend/client/data/Int8Handler.java
+++ b/databend-client/src/main/java/com/databend/client/data/Int8Handler.java
@@ -566,6 +566,10 @@ class BooleanHandler implements ColumnTypeHandler {
         }
     }
 
+    /**
+     * If boolean column is string, only "1" and "true" will be judged as true,
+     * otherwise it is false.
+     */
     private static final String TRUE_NUM = "1";
     private static final String TRUE_STRING = "true";
 

--- a/databend-client/src/main/java/com/databend/client/data/Int8Handler.java
+++ b/databend-client/src/main/java/com/databend/client/data/Int8Handler.java
@@ -566,12 +566,15 @@ class BooleanHandler implements ColumnTypeHandler {
         }
     }
 
+    private static final String TRUE_NUM = "1";
+    private static final String TRUE_STRING = "true";
+
     private Boolean parseNullableValue(Object value) {
         if (value == null || value.equals("NULL")) {
             return null;
         }
         if (value instanceof String) {
-            return Boolean.parseBoolean((String) value);
+            return TRUE_NUM.equals(value) || TRUE_STRING.equals(value);
         }
         if (value instanceof Number) {
             return ((Number) value).intValue() != 0;
@@ -584,7 +587,7 @@ class BooleanHandler implements ColumnTypeHandler {
             throw new IllegalArgumentException("Boolean type is not nullable");
         }
         if (value instanceof String) {
-            return Boolean.parseBoolean((String) value);
+            return TRUE_NUM.equals(value) || TRUE_STRING.equals(value);
         }
         if (value instanceof Number) {
             return ((Number) value).intValue() != 0;


### PR DESCRIPTION
If a column's type is boolean, databend-jdbc will always return `false`.

The reason for this bug has been found so far is because the boolean type data returned via databend is either "1" or "0" and can never be true via a conversion by `Boolean.parseBoolean((String) value)`.

Now fix this problem, only `true` if the returned data is "true" or "1", other types of string data are `false`.