### PR TITLE
Convert TABLE_TYPE to jdbc standard type

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendUnboundQueryResultSet.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendUnboundQueryResultSet.java
@@ -1,0 +1,40 @@
+package com.databend.jdbc;
+
+import com.databend.client.QueryRowField;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * We create a new ResultSet class constructed directly from fixed values or pre-query combinations of data.
+ * This class is created to do some specific processing on some implementations of the DatabaseMetaData interface.
+ * <p>
+ * Since some of the queries returned from databend will be some different from the jdbc standard,
+ * so that we need to make some modifications to the types, values, etc. after the returned results.
+ * The actual returned datas from the interface is a new ResultSet.
+ */
+public class DatabendUnboundQueryResultSet extends AbstractDatabendResultSet {
+
+    private boolean closed = false;
+
+    DatabendUnboundQueryResultSet(Optional<Statement> statement, List<QueryRowField> schema, Iterator<List<Object>> results) {
+        super(statement, schema, results);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        Statement statement = getStatement();
+        if (statement != null) {
+            statement.close();
+        }
+        this.closed = true;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+}

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
@@ -11,9 +11,12 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestDatabendDatabaseMetaData {
     private static void assertTableMetadata(ResultSet rs)
@@ -178,6 +181,24 @@ public class TestDatabendDatabaseMetaData {
             DatabaseMetaData metaData = connection.getMetaData();
             try (ResultSet rs = connection.getMetaData().getPrimaryKeys(null, null, null)) {
                 assertEquals(rs.getMetaData().getColumnCount(), 6);
+            }
+        }
+    }
+
+    @Test(groups = {"IT"})
+    public void testTableTypes() throws Exception {
+        try (Connection connection = createConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            try (ResultSet rs = metaData.getTableTypes()) {
+                assertEquals(rs.getMetaData().getColumnCount(), 1);
+                List<String> totalTableTypes = new ArrayList<>();
+                while (rs.next()) {
+                    totalTableTypes.add(rs.getString(1));
+                }
+                assertEquals(totalTableTypes.size(), 3);
+                assertTrue(totalTableTypes.contains("TABLE"));
+                assertTrue(totalTableTypes.contains("VIEW"));
+                assertTrue(totalTableTypes.contains("SYSTEM TABLE"));
             }
         }
     }


### PR DESCRIPTION
Issue: https://github.com/databendcloud/databend-jdbc/issues/86

Current conversion:
* `TABLE`(Jdbc) -> `BASE TABLE`(Databend)
* `SYSTEM VIEW`(Jdbc) to `SYSTEM TABLE`(Databend)

Meanwhile, the implementation of `getTableTypes` method has been changed to return a fixed result, and MySQL JDBC is as consistent as possible.