### PR TITLE
Close Statement when ResultSet that returned in DatabendDatabaseMetaData is closing

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDatabaseMetaData.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDatabaseMetaData.java
@@ -1633,6 +1633,10 @@ public class DatabendDatabaseMetaData implements DatabaseMetaData
         DatabendResultSet resultSet;
         try {
             resultSet = (DatabendResultSet) statement.executeQuery(sql);
+            // MetaData generally returns only a ResultSet object.
+            // Therefore, the Statement is hidden in the ResultSet class and can not be invoked normally.
+            // Close Statement when closing ResultSet, so that we can clear it in Connection
+            resultSet.setCloseStatementOnClose();
         }
         catch (Throwable e) {
             try {


### PR DESCRIPTION
Issue: https://github.com/databendcloud/databend-jdbc/issues/83

Enable the close statement method at the same time we close the resultset, so that the connection can reclaim unused statements.