### PR TITLE
fix: fix prepareCall

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendConnection.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendConnection.java
@@ -149,7 +149,7 @@ public class DatabendConnection implements Connection, FileTransferAPI {
     @Override
     public CallableStatement prepareCall(String s)
             throws SQLException {
-        return null;
+        throw new SQLFeatureNotSupportedException("prepareCall");
     }
 
     @Override
@@ -349,7 +349,6 @@ public class DatabendConnection implements Connection, FileTransferAPI {
     @Override
     public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
             throws SQLException {
-//        checkHoldability(resultSetHoldability);
         return prepareCall(sql, resultSetType, resultSetConcurrency);
     }
 


### PR DESCRIPTION
When use Druild create jdbc pool this will cause null point exception.